### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TheOneHyer/InteractiveTextAnalyzer/security/code-scanning/11](https://github.com/TheOneHyer/InteractiveTextAnalyzer/security/code-scanning/11)

To fix this problem, you should add an explicit `permissions` block to the workflow file. The recommended location is at the root level—just below the workflow name and above the `on:` key—so it applies to all jobs unless overridden. For a Node.js CI workflow that does not interact with issues, pull requests, or modify repository content, the minimal permission required is `contents: read`. You only need to edit the `.github/workflows/node.js.yml` file, adding the block directly after the workflow `name:` entry.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
