### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 ---
 name: Run Tests
-
+permissions:
+  contents: read
 'on':
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/TheOneHyer/InteractiveTextAnalyzer/security/code-scanning/12](https://github.com/TheOneHyer/InteractiveTextAnalyzer/security/code-scanning/12)

To fix the problem, add an explicit `permissions` block to `.github/workflows/test.yml` to restrict the default token permissions to the minimal needed for this workflow. The recommended minimum for most typical CI pipelines is `contents: read`, which allows the workflow to check out code and read repository contents but not push changes or access other privileged operations. You can add this block either at the top level (to apply to all jobs) or at the `test` job level. The best way, to keep things clear and minimal, is to add `permissions:` at the root, right after the workflow `name:` (and before `on:`), like this:

```yaml
name: Run Tests
permissions:
  contents: read
on:
  ...
```

This ensures all jobs default to read-only contents access, adhering to the principle of least privilege. No new imports, dependencies, or further changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
